### PR TITLE
Use device ID and secret to secure DB access

### DIFF
--- a/app/src/main/java/edu/gatech/cc/cellwatch/CellWatchApp.kt
+++ b/app/src/main/java/edu/gatech/cc/cellwatch/CellWatchApp.kt
@@ -35,11 +35,14 @@ class CellWatchApp : Application() {
             MeasurementRepository(
                 database.measurementDao(),
                 database.fccSubmissionDao(),
-                NetworkMeasurementDatasource
+                networkMeasurementDatasource
             )
         }
         private val localDataStore by lazy {
             LocalDataStore(applicationContext())
+        }
+        private val networkMeasurementDatasource by lazy {
+            NetworkMeasurementDatasource(localDataStore)
         }
         val settingsRepository by lazy {
             SettingsRepository(localDataStore)

--- a/app/src/main/java/edu/gatech/cc/cellwatch/core/util/Encryptor.kt
+++ b/app/src/main/java/edu/gatech/cc/cellwatch/core/util/Encryptor.kt
@@ -1,0 +1,68 @@
+package edu.gatech.cc.cellwatch.core.util
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+object Encryptor {
+    private const val PROVIDER = "AndroidKeyStore"
+    private const val ALGO = KeyProperties.KEY_ALGORITHM_AES
+    private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_GCM
+    private const val PADDING = KeyProperties.ENCRYPTION_PADDING_NONE
+    private const val KEY_SIZE = 256
+    private const val TAG_LENGTH = 128
+    private const val ALIAS = "cellwatch-device-key"
+
+    private val store by lazy { KeyStore.getInstance(PROVIDER).apply { load(null) } }
+    private val generator by lazy { KeyGenerator.getInstance(ALGO, PROVIDER) }
+    private val cipher by lazy { Cipher.getInstance("$ALGO/$BLOCK_MODE/$PADDING") }
+    private val charset by lazy { charset("UTF-8") }
+
+    init {
+        if (!store.containsAlias(ALIAS)) makeKey()
+    }
+
+    private fun makeKey(): SecretKey {
+        return generator.apply {
+            init(
+                KeyGenParameterSpec
+                    .Builder(ALIAS, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
+                    .setBlockModes(BLOCK_MODE)
+                    .setEncryptionPaddings(PADDING)
+                    .setKeySize(KEY_SIZE)
+                    .setRandomizedEncryptionRequired(true)
+                    .build()
+            )
+        }.generateKey()
+    }
+
+    private val key: SecretKey
+        get() = store.getEntry(ALIAS, null).let {
+            if (it !is KeyStore.SecretKeyEntry) {
+                throw RuntimeException("expected SecretKeyEntry, got $it")
+            }
+            it.secretKey
+        }
+
+    fun encrypt(data: String): String {
+        cipher.init(Cipher.ENCRYPT_MODE, key)
+        val dataBytes = data.toByteArray(charset)
+        val encryptedBytes = cipher.doFinal(dataBytes)
+        val allBytes = byteArrayOf(cipher.iv.size.toByte()) + cipher.iv + encryptedBytes
+        return Base64.encodeToString(allBytes, Base64.NO_WRAP)
+    }
+
+    fun decrypt(data: String): String {
+        val allBytes = Base64.decode(data, Base64.NO_WRAP)
+        val ivSize = allBytes[0].toInt()
+        val iv = allBytes.copyOfRange(1, ivSize + 1)
+        val dataBytes = allBytes.copyOfRange(ivSize + 1, allBytes.size)
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH, iv))
+        return cipher.doFinal(dataBytes).toString(charset)
+    }
+}

--- a/app/src/main/java/edu/gatech/cc/cellwatch/data/datastore/LocalDataStore.kt
+++ b/app/src/main/java/edu/gatech/cc/cellwatch/data/datastore/LocalDataStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.google.firebase.Firebase
 import com.google.firebase.crashlytics.crashlytics
+import edu.gatech.cc.cellwatch.core.util.Encryptor
 import edu.gatech.cc.cellwatch.core.util.Log
 import edu.gatech.cc.cellwatch.data.model.CollectionMode
 import kotlinx.coroutines.flow.Flow
@@ -20,6 +21,7 @@ class LocalDataStore(private val context: Context) {
     companion object {
         private val Context.dataStore: DataStore<Preferences> by preferencesDataStore("data_store")
         private val DEVICE_ID = stringPreferencesKey("device_id")
+        private val DEVICE_SECRET = stringPreferencesKey("device_secret")
         private val COLLECTION_MODE = stringPreferencesKey("collection_mode")
         private val FCC_POLICY_AGREED = booleanPreferencesKey("fcc_policy_agreed")
         private val USER_NAME = stringPreferencesKey("user_name")
@@ -37,6 +39,16 @@ class LocalDataStore(private val context: Context) {
             preferences[DEVICE_ID] = deviceId
         }
         Firebase.crashlytics.setCustomKey("device_id", deviceId)
+    }
+
+    val getDeviceSecret: Flow<String?> = context.dataStore.data.map { preferences ->
+        preferences[DEVICE_SECRET]?.let { Encryptor.decrypt(it) }
+    }
+
+    suspend fun saveDeviceSecret(secret: String) {
+        context.dataStore.edit { preferences ->
+            preferences[DEVICE_SECRET] = Encryptor.encrypt(secret)
+        }
     }
 
     val getCollectionMode: Flow<CollectionMode?> = context.dataStore.data.map { preferences ->

--- a/app/src/main/java/edu/gatech/cc/cellwatch/data/network/NetworkMeasurementDatasource.kt
+++ b/app/src/main/java/edu/gatech/cc/cellwatch/data/network/NetworkMeasurementDatasource.kt
@@ -3,6 +3,7 @@ package edu.gatech.cc.cellwatch.data.network
 import androidx.annotation.WorkerThread
 import edu.gatech.cc.cellwatch.BuildConfig
 import edu.gatech.cc.cellwatch.core.util.Log
+import edu.gatech.cc.cellwatch.data.datastore.LocalDataStore
 import edu.gatech.cc.cellwatch.data.model.FccSubmission
 import edu.gatech.cc.cellwatch.data.model.Measurement
 import edu.gatech.cc.cellwatch.data.model.asNetworkModel
@@ -10,6 +11,7 @@ import edu.gatech.cc.cellwatch.data.network.model.NetworkFccSubmission
 import edu.gatech.cc.cellwatch.data.network.model.NetworkMeasurement
 import edu.gatech.cc.cellwatch.data.network.model.NetworkMeasurementWithData
 import edu.gatech.cc.cellwatch.data.network.model.asExternalModel
+import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.exceptions.RestException
@@ -17,6 +19,10 @@ import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.postgrest.query.Columns
 import io.github.jan.supabase.postgrest.rpc
+import io.ktor.client.plugins.api.createClientPlugin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.IOException
 
 /**
@@ -26,26 +32,69 @@ import java.io.IOException
  * [Measurement] records to Supabase.
  */
 
-object NetworkMeasurementDatasource {
+class NetworkMeasurementDatasource(private val localDataStore: LocalDataStore) {
     private val TAG = this::class.simpleName
 
-    private const val supabaseUrl = BuildConfig.SUPABASE_URL
-    private const val supabaseApiKey = BuildConfig.SUPABASE_API_KEY
+    private val supabaseUrl = BuildConfig.SUPABASE_URL
+    private val supabaseApiKey = BuildConfig.SUPABASE_API_KEY
 
-    private val supabaseClient = createSupabaseClient(
-            supabaseUrl = supabaseUrl,
-            supabaseKey = supabaseApiKey
-        ) {
-            install(Postgrest)
+    private var _client: SupabaseClient? = null // use getClient(), not this field!
+    private val clientLock = Mutex()
+    private suspend fun getClient(): SupabaseClient {
+        // Only allow one attempt to create a client at a time to avoid registration errors (i.e.,
+        // one thread registers and then another also tries to register but gets an error because
+        // the same id was already registered by the first thread). Once the lock is acquired, do a
+        // second check for a non-null _client just in case another thread set it while we were
+        // waiting.
+        return _client ?: clientLock.withLock {
+            var client = _client
+            if (client != null) {
+                return client
+            }
+
+            val deviceId = localDataStore.getDeviceId.first()
+            val deviceSecret = localDataStore.getDeviceSecret.first() ?: registerDevice(deviceId)
+
+            client = createSupabaseClient(
+                supabaseUrl = supabaseUrl,
+                supabaseKey = supabaseApiKey
+            ) {
+                install(Postgrest)
+
+                httpConfig {
+                    install(createClientPlugin("DeviceHeaderPlugin") {
+                        onRequest { request, _ ->
+                            request.headers.append("X-Device-ID", deviceId)
+                            request.headers.append("X-Device-Secret", deviceSecret)
+                        }
+                    })
+                }
+            }
+
+            _client = client
+            return client
         }
+    }
 
-    private val measurementTable = supabaseClient.postgrest["measurements"]
-    private val fccSubmissionTable = supabaseClient.postgrest["fcc_submissions"]
+    private suspend fun registerDevice(id: String): String {
+        try {
+            val client = createSupabaseClient(supabaseUrl, supabaseApiKey) { install(Postgrest) }
+            val secret = client.postgrest
+                .rpc("register_device", mapOf("device_id" to id))
+                .decodeAs<String>()
+            localDataStore.saveDeviceSecret(secret)
+            Log.i(TAG, "device registered with id $id")
+            return secret
+        } catch (e: Exception) {
+            Log.i(TAG, "device registration failed for id $id", e)
+            throw e
+        }
+    }
 
     @WorkerThread
     suspend fun insertFccSubmission(fccSubmission: FccSubmission): FccSubmission {
         return withErrorHandling {
-            fccSubmissionTable.insert(fccSubmission.asNetworkModel())
+            getClient().postgrest["fcc_submissions"].insert(fccSubmission.asNetworkModel())
                 .decodeSingle<NetworkFccSubmission>().asExternalModel()
         }
     }
@@ -68,7 +117,7 @@ object NetworkMeasurementDatasource {
         )
 
         return withErrorHandling {
-            supabaseClient.postgrest.rpc("insert_measurement", networkMeasurementData)
+            getClient().postgrest.rpc("insert_measurement", networkMeasurementData)
                 .decodeAs<NetworkMeasurement>().asExternalModel()
         }
     }
@@ -76,7 +125,7 @@ object NetworkMeasurementDatasource {
     @WorkerThread
     suspend fun getMeasurementById(measurementId: String): Measurement {
         return withErrorHandling {
-            measurementTable.select(
+            getClient().postgrest["measurements"].select(
                 columns = Columns.raw("""*,upload_download_data(*),latency_data(*),locations(*),cells(*)""")
             ) {
                 Measurement::id eq measurementId


### PR DESCRIPTION
Implement a new auth flow that will limit each device to only accessing or inserting data tied to its device ID. Corresponding DB changes, including enabling row-level security and creating the registration function, are documented in the server repository.

Before each interaction with the Supabase DB, check whether we have a device secret stored. If not, register with the DB to get a secret. Store the secret encrypted in the local data store.

Include the device ID and secret as HTTP headers on every request to Supabase, allowing the DB to verify that we are the original owner of the device ID.

The database only stores a hashed version of the device secret. There remain two ways for an attacker to obtain the secret and thereby insert or read data corresponding to a device ID that it hasn't registered:

1. By breaking into Android's KeyStore to get the encryption key used when storing the secret locally.
2. By compromising the HTTPS connection between the device and Supabase and extracting the header.

These attack vectors both require defeating existing, time- and battle-tested security mechanisms.

As a result of these changes, the Supabase anon key that the app uses no longer needs to be treated as a secret. It still won't be shared publicly, but the risk factor from someone extracting it from an APK is now significantly lower.

Note that anyone with the anon key could register a device ID and insert fake data. However, they would only be able to read data tied to a device ID that they register. Additionally, any data that they insert must be tied to a device ID that they've registered and therefore could be easily removed once identified.